### PR TITLE
Moved the link for the Ring of Shadows under the Oliver encounter

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -482,6 +482,7 @@
 # House in Deep Shadows
 - Play hide and seek with [a child](https://bg3.wiki/wiki/Oliver), get [a cool ring](https://bg3.wiki/wiki/Ring_of_Shadows)
   - ::item_uncommon:: [Ring of Mental Inhibition](https://bg3.wiki/wiki/Ring%20of%20Mental%20Inhibition)
+  - ::item_uncommon:: [Ring of Shadows](https://bg3.wiki/wiki/Ring%20of%20Shadows)
 # Ruined Battlefield
 - ::item_story:: First opportunity to find a [Moonlantern](https://bg3.wiki/wiki/Moonlantern), dropped from [Kar'niss](https://bg3.wiki/wiki/Kar%27niss).
   - ::missable:: This version of the item is time limited and, depending on how the player entered Act 2, must be obtained before the target reaches Moonrise Towers.  It is recommended to obtain this item ASAP.
@@ -492,9 +493,7 @@
 - ::item_uncommon:: [Gloomstrand Shield](https://bg3.wiki/wiki/Gloomstrand%20Shield)
 - ::item_uncommon:: [Ironwood Club](https://bg3.wiki/wiki/Ironwood%20Club)
 - ::item_uncommon:: [Luminous Gloves](https://bg3.wiki/wiki/Luminous%20Gloves)
-
 - ::item_uncommon:: [Ring of Self Immolation](https://bg3.wiki/wiki/Ring%20of%20Self%20Immolation)
-
 - Trim some [hedges](https://bg3.wiki/wiki/Shadow-Cursed_Vine_Blight)
   - ::item_uncommon:: [Frost Prince](https://bg3.wiki/wiki/Frost%20Prince)
 - Talk to a man who wants to [make things "right" by interrogating a dead barkeeper](https://bg3.wiki/wiki/Punish_the_Wicked)
@@ -1079,7 +1078,6 @@
 - ::item_rare:: [Studded Shield +1](https://bg3.wiki/wiki/Studded%20Shield%20+1)
 - ::item_uncommon:: [Sylvan Scimitar](https://bg3.wiki/wiki/Sylvan%20Scimitar)
 - ::item_uncommon:: [Murderous Cut](https://bg3.wiki/wiki/Murderous%20Cut)
-- ::item_uncommon:: [Ring of Shadows](https://bg3.wiki/wiki/Ring%20of%20Shadows)
 - ::item_common:: [Azer Warhammer](https://bg3.wiki/wiki/Azer%20Warhammer)
 - ::item_common:: [Damaged Scale Mail](https://bg3.wiki/wiki/Damaged%20Scale%20Mail)
 - ::item_common:: [Flail of the Vortex](https://bg3.wiki/wiki/Flail%20of%20the%20Vortex)


### PR DESCRIPTION
Moved the link for the [Ring of Shadows](https://bg3.wiki/wiki/Ring%20of%20Shadows) under the Oliver checklist item in the House in Deep Shadows section.